### PR TITLE
Fix installation command syntax for macOS/Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Install [Sideberry](https://addons.mozilla.org/en-US/firefox/addon/sidebery/), t
 
 **macOS / Linux:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/tompassarelli/palefox/css-legacy/install.sh | bash
+bash <(curl -fsSL https://raw.githubusercontent.com/tompassarelli/palefox/css-legacy/install.sh)
 ```
 
 **Windows** (PowerShell):


### PR DESCRIPTION
Update installation command for macOS/Linux in README to be interactive, so users can choose the profile and browser