### PR TITLE
fix: size findbar to content and show all native controls

### DIFF
--- a/chrome/palefox.css
+++ b/chrome/palefox.css
@@ -947,7 +947,10 @@ body:has(#sidebar-box[hidden]):has(#identity-box.notSecure)::before {
   position: absolute;
   bottom: 8px;
   right: 16px;
-  width: 320px;
+  width: max-content;
+  max-width: calc(100% - 32px);
+  contain: none !important;
+  overflow-x: visible !important;
   padding: 4px 8px !important;
   background: var(--pfx-color) !important;
   border: 1px solid color-mix(in srgb, currentColor, transparent 87%) !important;
@@ -970,10 +973,6 @@ body:has(#sidebar-box[hidden]):has(#identity-box.notSecure)::before {
 }
 
 .browserContainer > findbar .findbar-closebutton {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  right: 12px;
   margin: 0 !important;
   padding: 4px !important;
 }


### PR DESCRIPTION
Replace hardcoded width with max-content and override Firefox's default contain: inline-size, which was collapsing the bar to 1px min-width. Tested on MacOS

Before:
<img width="356" height="88" alt="problem1" src="https://github.com/user-attachments/assets/18c0379c-3f77-4e4d-bb3b-a08bf58e6ced" />
After:
<img width="1021" height="80" alt="Screenshot 2026-04-18 at 9 46 16 PM" src="https://github.com/user-attachments/assets/5281ee27-ed61-4b22-9151-735b9c2df1a8" />
